### PR TITLE
build: 開発環境の近代化

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((nil . ((lsp-format-buffer-on-save . t))))

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,20 @@
 root = true
+
 [*]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+max_line_length = 120
+
+[*.hs]
 indent_style = space
 indent_size = 2
-# 人間が読みやすいとか以前の問題で、HTMLファイルは改行に意味を持っているので、雑に改行されると困る。
-# 120を超えるのは何かを考え直した方が良いと思いますが。
-max_line_length = 120
+
+[*.md]
+# Markdownには最後にスペース2つ入れて強制改行するシンタックスがあるので末尾のスペースを許可。
+# 注意: なるべく強制改行は使わず、意味で段落して、改行位置はクライアントのデバイスに任せるべき。
+trim_trailing_whitespace = false
+# 順序付きリストをネストする時に、インデント幅を2にすると適切にパース出来ない事が多い(GitHubも)ので4にする。
+indent_size = 4

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,6 @@
+{
+  "Disable": {
+    "IndentSize": true,
+    "MaxLineLength": true
+  }
+}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,4 +18,8 @@ jobs:
         with:
           extra_nix_config: |
             accept-flake-config = true
+      - uses: cachix/cachix-action@v16
+        with:
+          name: www-ncaq-net
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix flake check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,21 @@
+name: check
+
+on:
+  push:
+    branches: master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read # リポジトリコンテンツの読み取り
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+      - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ flycheck_*.el
 .projectile
 
 # directory configuration
-.dir-locals.el
+# .dir-locals.el
 
 # network security
 /network-security.data

--- a/flake.lock
+++ b/flake.lock
@@ -691,7 +691,9 @@
           "flake-utils",
           "systems"
         ],
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
       },
       "locked": {
         "lastModified": 1743690424,
@@ -717,7 +719,8 @@
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "poetry2nix": "poetry2nix"
+        "poetry2nix": "poetry2nix",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "stackage": {
@@ -754,16 +757,16 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
-          "poetry2nix",
-          "nixpkgs"
+          "haskellNix",
+          "nixpkgs-unstable"
         ]
       },
       "locked": {
-        "lastModified": 1730120726,
-        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
+        "lastModified": 1756662192,
+        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
+        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
           corepack.overlays.default
           (final: prev: {
             # 公式リリースがしばらくないのでGitHubの最新版を利用。
-            html-tidy = prev.html-tidy.overrideAttrs (oldAttrs: {
+            html-tidy = prev.html-tidy.overrideAttrs (_oldAttrs: {
               src = html-tidy-src;
             });
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,8 +24,17 @@
   };
 
   outputs =
-    { nixpkgs, flake-utils, haskellNix, poetry2nix, corepack, html-tidy-src, ... }:
-    flake-utils.lib.eachSystem ["x86_64-linux"] (system:
+    {
+      nixpkgs,
+      flake-utils,
+      haskellNix,
+      poetry2nix,
+      corepack,
+      html-tidy-src,
+      ...
+    }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (
+      system:
       let
         overlays = [
           haskellNix.overlay
@@ -33,19 +42,22 @@
           corepack.overlays.default
           (final: prev: {
             # 公式リリースがしばらくないのでGitHubの最新版を利用。
-            html-tidy =
-              prev.html-tidy.overrideAttrs (oldAttrs: { src = html-tidy-src; });
+            html-tidy = prev.html-tidy.overrideAttrs (oldAttrs: {
+              src = html-tidy-src;
+            });
 
             # Poetry2nixでPythonパッケージを管理
             pythonEnv = final.poetry2nix.mkPoetryEnv {
               projectDir = ./.;
               python = final.python312;
               preferWheels = true;
-              overrides = final.poetry2nix.overrides.withDefaults (self: super: {
-                jsx-lexer = super.jsx-lexer.overridePythonAttrs (old: {
-                  buildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools ];
-                });
-              });
+              overrides = final.poetry2nix.overrides.withDefaults (
+                self: super: {
+                  jsx-lexer = super.jsx-lexer.overridePythonAttrs (old: {
+                    buildInputs = (old.buildInputs or [ ]) ++ [ self.setuptools ];
+                  });
+                }
+              );
             };
 
             project = final.haskell-nix.stackProject' {
@@ -86,16 +98,21 @@
           inherit (haskellNix) config;
         };
         flake = pkgs.project.flake { };
-      in flake // {
+      in
+      flake
+      // {
         packages = flake.packages // {
           default = flake.packages."www-ncaq-net:exe:www-ncaq-net";
         };
-      });
+      }
+    );
 
   nixConfig = {
-    extra-substituters = [ "https://cache.nixos.org" "https://cache.iog.io" ];
-    extra-trusted-public-keys =
-      [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
+    extra-substituters = [
+      "https://cache.nixos.org"
+      "https://cache.iog.io"
+    ];
+    extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
     allow-import-from-derivation = true;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -154,8 +154,12 @@
     extra-substituters = [
       "https://cache.nixos.org"
       "https://cache.iog.io"
+      "https://www-ncaq-net.cachix.org"
     ];
-    extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      "www-ncaq-net.cachix.org-1:muU00ItcyCf+F+lS//4w9XxW+UZYQxGa1cra1VXRH8c="
+    ];
     allow-import-from-derivation = true;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,11 @@
         };
         flake = pkgs.project.flake { };
       in
-      flake
+      # hydraJobsもGitHub Actionsを使うため不要なので除外。
+      builtins.removeAttrs flake [
+        "ciJobs"
+        "hydraJobs"
+      ]
       // {
         packages = flake.packages // {
           default = flake.packages."www-ncaq-net:exe:www-ncaq-net";

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,8 +1,7 @@
 indentation: 2
-comma-style: leading # for lists, tuples etc. - can also be 'trailing'
-record-brace-space: false # rec {x = 1} vs. rec{x = 1}
-indent-wheres: false # 'false' means save space by only half-indenting the 'where' keyword
-diff-friendly-import-export: true # 'false' uses Ormolu-style lists
-respectful: true # don't be too opinionated about newlines etc.
-haddock-style: multi-line # '--' vs. '{-'
-newlines-between-decls: 1 # number of newlines between top-level declarations
+column-limit: 120
+function-arrows: leading
+import-export-style: leading
+haddock-style: single-line
+sort-constraints: true
+sort-derived-classes: true

--- a/site.hs
+++ b/site.hs
@@ -1,22 +1,22 @@
 module Main (main) where
 
-import           Control.Applicative
-import           Data.Convertible
-import qualified Data.List           as L
-import qualified Data.List.Split     as L
-import           Data.Maybe
-import qualified Data.Text           as T
-import           Hakyll
-import           System.Directory
-import           System.FilePath
-import           Text.Pandoc
-import           Text.Pandoc.Shared  (eastAsianLineBreakFilter)
-import           Text.Regex.TDFA     hiding (empty, match)
+import Control.Applicative
+import Data.Convertible
+import qualified Data.List as L
+import qualified Data.List.Split as L
+import Data.Maybe
+import qualified Data.Text as T
+import Hakyll
+import System.Directory
+import System.FilePath
+import Text.Pandoc
+import Text.Pandoc.Shared (eastAsianLineBreakFilter)
+import Text.Regex.TDFA hiding (empty, match)
 
 main :: IO ()
 main =
-  getEntryAndYears >>=
-  hakyllRun
+  getEntryAndYears
+    >>= hakyllRun
 
 -- | 年一覧をスマートにページネーションする方法がわからなかったので`IO`でごり押しする。
 -- `Rules`は内部的には`IO`をベースに持つが、
@@ -58,37 +58,37 @@ hakyllRun (entryIndex, years) = hakyllWith conf $ do
   match "404.md" $ do
     route $ setExtension "html"
     compile $
-      pandocCompilerCustom >>=
-      saveSnapshot "content" >>=
-      loadAndApplyTemplate "templates/entry.html" entryContext >>=
-      loadAndApplyTemplate "templates/default.html" (addTitleWithSuffix <> entryIndexField <> entryContext) >>=
-      tidyHtml
+      pandocCompilerCustom
+        >>= saveSnapshot "content"
+        >>= loadAndApplyTemplate "templates/entry.html" entryContext
+        >>= loadAndApplyTemplate "templates/default.html" (addTitleWithSuffix <> entryIndexField <> entryContext)
+        >>= tidyHtml
 
   -- 大多数の記事。
   match ("*.md" .||. "entry/*.md") $ do
     route cleanRoute
     compile $
-      pandocCompilerCustom >>=
-      saveSnapshot "content" >>=
-      loadAndApplyTemplate "templates/entry.html" entryContext >>=
-      loadAndApplyTemplate "templates/default.html" (addTitleWithSuffix <> entryIndexField <> entryContext) >>=
-      tidyHtml
+      pandocCompilerCustom
+        >>= saveSnapshot "content"
+        >>= loadAndApplyTemplate "templates/entry.html" entryContext
+        >>= loadAndApplyTemplate "templates/default.html" (addTitleWithSuffix <> entryIndexField <> entryContext)
+        >>= tidyHtml
 
   -- サイトのトップレベル。
   match "index.html" $ do
     route idRoute
     let context =
-          listField "entry" entryContext (L.take 5 . reverse <$> loadAll (fromGlob "entry/*.md")) <>
-          indexContext
-          "ncaq"
-          "ncaq website root"
-          "website"
-          entryIndexField
+          listField "entry" entryContext (L.take 5 . reverse <$> loadAll (fromGlob "entry/*.md"))
+            <> indexContext
+              "ncaq"
+              "ncaq website root"
+              "website"
+              entryIndexField
     compile $
-      getResourceBody >>=
-      applyAsTemplate context >>=
-      loadAndApplyTemplate "templates/default.html" context >>=
-      tidyHtml
+      getResourceBody
+        >>= applyAsTemplate context
+        >>= loadAndApplyTemplate "templates/default.html" context
+        >>= tidyHtml
 
   -- 年ごとの記事一覧。
   -- 何でも良いけれど適当に区切らないとGoogleがインデックスを拒否する。
@@ -96,32 +96,32 @@ hakyllRun (entryIndex, years) = hakyllWith conf $ do
         create [fromFilePath $ year <> "/index.html"] $ do
           route $ constRoute $ year <> "/index.html"
           let context =
-                listField "entry" entryContext (reverse <$> loadAll (fromGlob $ "entry/" <> year <> "*.md")) <>
-                indexContext
-                (year <> "年の記事一覧 - ncaq")
-                (year <> "年の記事一覧 - ncaq")
-                "website"
-                entryIndexField
+                listField "entry" entryContext (reverse <$> loadAll (fromGlob $ "entry/" <> year <> "*.md"))
+                  <> indexContext
+                    (year <> "年の記事一覧 - ncaq")
+                    (year <> "年の記事一覧 - ncaq")
+                    "website"
+                    entryIndexField
           compile $
-            makeItem entryIndex >>=
-            applyAsTemplate context >>=
-            loadAndApplyTemplate "templates/default.html" context
+            makeItem entryIndex
+              >>= applyAsTemplate context
+              >>= loadAndApplyTemplate "templates/default.html" context
   mapM_ entryIndexOfYear years
 
   -- ファイル以外の情報を元にサイトマップを毎回更新する。
   create ["sitemap.xml"] $ do
     route idRoute
     let sitemapContext =
-          listField "entry" entryContext (reverse . filter not404 <$> loadAll ("*.md" .||. "entry/*.md")) <>
-          entryIndexField
+          listField "entry" entryContext (reverse . filter not404 <$> loadAll ("*.md" .||. "entry/*.md"))
+            <> entryIndexField
         not404 item = toFilePath (itemIdentifier item) /= "404.md"
     compile $
-      getResourceBody >>=
-      applyAsTemplate sitemapContext >>=
-      tidyXml
+      getResourceBody
+        >>= applyAsTemplate sitemapContext
+        >>= tidyXml
 
   -- ファイル以外の情報を元にフィードを毎回更新する。
-  --フィード対象はentry以下のみ。
+  -- フィード対象はentry以下のみ。
   create ["feed.atom"] $ do
     route idRoute
     compile $ do
@@ -131,10 +131,11 @@ hakyllRun (entryIndex, years) = hakyllWith conf $ do
 
 -- | Hakyllに渡す設定。
 conf :: Configuration
-conf = def
-  { providerDirectory = "site"
-  , deployCommand = "yarn wrangler pages deploy _site --project-name www-ncaq-net"
-  }
+conf =
+  def
+    { providerDirectory = "site"
+    , deployCommand = "yarn wrangler pages deploy _site --project-name www-ncaq-net"
+    }
 
 -- | Pandocの設定。
 pandocCompilerCustom :: Compiler (Item String)
@@ -142,112 +143,121 @@ pandocCompilerCustom =
   let extensions =
         -- 大したこと無いように見えて結構パフォーマンスに影響するので無効化する。
         disableExtension Ext_pandoc_title_block $
-        -- 記号を変に変えられるのは困るので無効化する。
-        disableExtension Ext_smart $
-        -- 一応自動見出し向けのidを入れる。
-        enableExtension Ext_auto_identifiers $
-        readerExtensions defaultHakyllReaderOptions
+          -- 記号を変に変えられるのは困るので無効化する。
+          disableExtension Ext_smart $
+            -- 一応自動見出し向けのidを入れる。
+            enableExtension Ext_auto_identifiers $
+              readerExtensions defaultHakyllReaderOptions
       -- pygmentizeでシンタックスハイライト。
       transform (CodeBlock (_identifier, classes, _keyValue) str) =
         let fileName = T.unwords classes
             fileKind = if T.null fileName then T.unwords classes else fileName
-        in RawBlock (Format "html") . convert <$>
-           unixFilter "poetry"
-           (["run", "pygmentize", "-f", "html"] <> if T.null fileKind then [] else ["-l", convert fileKind])
-           (convert str)
+         in RawBlock (Format "html") . convert
+              <$> unixFilter
+                "poetry"
+                (["run", "pygmentize", "-f", "html"] <> if T.null fileKind then [] else ["-l", convert fileKind])
+                (convert str)
       transform x = return x
-  in pandocCompilerWithTransformM
-     defaultHakyllReaderOptions
-     { readerExtensions = extensions
-     }
-     defaultHakyllWriterOptions
-     { writerHTMLMathMethod = MathML
-     , writerSectionDivs = True -- HTML sectionの方を使う。
-     , writerExtensions = extensions
-     , writerHighlightStyle = Nothing -- 対応言語が多いPygmentでシンタックスハイライトを行うためPandoc側では不要。
-     }
-     -- 東アジアの文字列に余計な空白が入らないようにする。
-     -- 何故かコマンドラインオプションでは有効にならない。
-     (bottomUpM transform . eastAsianLineBreakFilter)
+   in pandocCompilerWithTransformM
+        defaultHakyllReaderOptions
+          { readerExtensions = extensions
+          }
+        defaultHakyllWriterOptions
+          { writerHTMLMathMethod = MathML
+          , writerSectionDivs = True -- HTML sectionの方を使う。
+          , writerExtensions = extensions
+          , writerHighlightStyle = Nothing -- 対応言語が多いPygmentでシンタックスハイライトを行うためPandoc側では不要。
+          }
+        -- 東アジアの文字列に余計な空白が入らないようにする。
+        -- 何故かコマンドラインオプションでは有効にならない。
+        (bottomUpM transform . eastAsianLineBreakFilter)
 
 -- | Markdownの記事として独立しているページ向け。
 entryContext :: Context String
 entryContext =
-  let context = mconcat
-        [ titleEscape
-        , mconcat entryDate
-        , teaserFieldByResource 256 "teaser" "content" id
-        , teaserFieldByResource 100 "description" "content" escapeDoubleQuote
-        , teaserFieldByResource 180 "og-description" "content" escapeDoubleQuote
-        , basicContext
+  let context =
+        mconcat
+          [ titleEscape
+          , mconcat entryDate
+          , teaserFieldByResource 256 "teaser" "content" id
+          , teaserFieldByResource 100 "description" "content" escapeDoubleQuote
+          , teaserFieldByResource 180 "og-description" "content" escapeDoubleQuote
+          , basicContext
+          ]
+   in mconcat
+        [ context
+        , openGraphField "opengraph" context
         ]
-  in mconcat
-     [ context
-     , openGraphField "opengraph" context
-     ]
-  where titleEscape = mapTitleEx (fmap escapeHtml)
-        entryDate = f <$> ["date", "published"]
-          where f key = field key (\item -> do
-                                      mMeta <- getMetadataField (itemIdentifier item) key
-                                      case mMeta of
-                                        Nothing   -> return $ fromMaybe empty $ mItemDate item
-                                        Just meta -> return meta
-                                  )
-        mItemDate item = case L.splitOneOf "-" f of
-          [year, month, day, hour, minute, second] ->
-            Just $ concat [year, "-", month, "-", day, "T", hour, ":", minute, ":", second, "+09:00"]
-          [year, month, day] ->
-            Just $ concat [year, "-", month, "-", day]
-          _ -> Nothing
-          where f = toFilePath $ cleanIdentifier $ itemIdentifier item
-                cleanIdentifier = fromFilePath . dropExtension . takeFileName . toFilePath
+ where
+  titleEscape = mapTitleEx (fmap escapeHtml)
+  entryDate = f <$> ["date", "published"]
+   where
+    f key =
+      field
+        key
+        ( \item -> do
+            mMeta <- getMetadataField (itemIdentifier item) key
+            case mMeta of
+              Nothing -> return $ fromMaybe empty $ mItemDate item
+              Just meta -> return meta
+        )
+  mItemDate item = case L.splitOneOf "-" f of
+    [year, month, day, hour, minute, second] ->
+      Just $ concat [year, "-", month, "-", day, "T", hour, ":", minute, ":", second, "+09:00"]
+    [year, month, day] ->
+      Just $ concat [year, "-", month, "-", day]
+    _ -> Nothing
+   where
+    f = toFilePath $ cleanIdentifier $ itemIdentifier item
+    cleanIdentifier = fromFilePath . dropExtension . takeFileName . toFilePath
 
 -- | フィールドのtitleデータを編集します。
 -- タイトルが無い場合はエラーを出力して終了します。
-mapTitleEx :: MonadMetadata f => (f String -> Compiler String) -> Context a
+mapTitleEx :: (MonadMetadata f) => (f String -> Compiler String) -> Context a
 mapTitleEx f = field "title" (f . getTitleEx)
 
 -- | メタデータからtitleを取得します。
 -- タイトルが無い場合はエラーを出力して終了します。
-getTitleEx :: MonadMetadata f => Item a -> f String
+getTitleEx :: (MonadMetadata f) => Item a -> f String
 getTitleEx item =
-  fromMaybe (error "title not found") <$>
-  getMetadataField (itemIdentifier item) "title"
+  fromMaybe (error "title not found")
+    <$> getMetadataField (itemIdentifier item) "title"
 
 -- | Markdownの記事ではなくHTMLから生成する一覧ページ。
 indexContext :: String -> String -> String -> Context String -> Context String
 indexContext title description ogType entryIndexField =
   mconcat
-  [ constField "title" title
-  , constField "description" description
-  , constField "og-type" ogType
-  , constField "og-description" description
-  , entryIndexField
-  , basicContext
-  ]
+    [ constField "title" title
+    , constField "description" description
+    , constField "og-type" ogType
+    , constField "og-description" description
+    , entryIndexField
+    , basicContext
+    ]
 
 -- | どのページにも共通する基本的な情報。
 basicContext :: Context String
 basicContext =
-  let context = mconcat
-        [ constField "root" "https://www.ncaq.net"
-        , cleanUrlField
-        , constField "og-image" "https://www.ncaq.net/favicon.png"
-        , constField "twitter-creator" "@ncaq"
-        , constField "twitter-site" "@ncaq"
-        , defaultContext
+  let context =
+        mconcat
+          [ constField "root" "https://www.ncaq.net"
+          , cleanUrlField
+          , constField "og-image" "https://www.ncaq.net/favicon.png"
+          , constField "twitter-creator" "@ncaq"
+          , constField "twitter-site" "@ncaq"
+          , defaultContext
+          ]
+   in mconcat
+        -- JSON-LDやOpenGraphはtypeがハードコーディングされているからあえて入れない。
+        [ twitterCardField "twitter" context
+        , context
         ]
-  in mconcat
-     -- JSON-LDやOpenGraphはtypeがハードコーディングされているからあえて入れない。
-     [ twitterCardField "twitter" context
-     , context
-     ]
 
 -- | 記事一覧などに利用するために記事の冒頭を指定された文字数で切り取ってキーに設定する。
 teaserFieldByResource :: Int -> String -> Snapshot -> (String -> String) -> Context a
 teaserFieldByResource size key snapshot escape = field key $ \item ->
-  dropWarningHtmlEntity . take size . escape . stripTags . itemBody <$>
-  loadSnapshot (itemIdentifier item) snapshot
+  dropWarningHtmlEntity . take size . escape . stripTags . itemBody
+    <$> loadSnapshot (itemIdentifier item) snapshot
 
 -- | HTMLエスケープされた記号が中途半端に残って別の意味になるのを防ぐため、
 -- 切り取った箇所の末尾がHTMLエスケープっぽかったら削除する。
@@ -255,7 +265,7 @@ teaserFieldByResource size key snapshot escape = field key $ \item ->
 dropWarningHtmlEntity :: String -> String
 dropWarningHtmlEntity entity =
   let (safety, _match, _after) = entity =~ ("&[^&;]*$" :: String) :: (String, String, String)
-  in safety
+   in safety
 
 -- | ダブルクオートを雑にエスケープする。
 -- 雑すぎるのでユーザが入力する可能性のある値を入れる場合許容できないが、
@@ -269,19 +279,21 @@ addTitleWithSuffix = mapTitleEx (fmap (<> " - ncaq"))
 
 -- | RSS Feed配信向けの設定。
 feedConfiguration :: FeedConfiguration
-feedConfiguration = FeedConfiguration
-  { feedTitle       = "ncaq"
-  , feedDescription = "www.ncaq.net entry"
-  , feedAuthorName  = "ncaq"
-  , feedAuthorEmail = "ncaq@ncaq.net"
-  , feedRoot        = "https://www.ncaq.net"
-  }
+feedConfiguration =
+  FeedConfiguration
+    { feedTitle = "ncaq"
+    , feedDescription = "www.ncaq.net entry"
+    , feedAuthorName = "ncaq"
+    , feedAuthorEmail = "ncaq@ncaq.net"
+    , feedRoot = "https://www.ncaq.net"
+    }
 
 -- | ファイルパスのハイフンをディレクトリ区切りに変換して、
 -- 末尾に`index.html`を付与してディレクトリのデフォルトとして参照されるようにする。
 cleanRoute :: Routes
 cleanRoute = customRoute createIndexRoute `composeRoutes` customHyphenToSlash
-  where createIndexRoute ident = takeBaseName (dropExtension (toFilePath ident)) </> "index.html"
+ where
+  createIndexRoute ident = takeBaseName (dropExtension (toFilePath ident)) </> "index.html"
 
 -- | ファイルパスのハイフンをディレクトリの区切り文字に変換する。
 customHyphenToSlash :: Routes
@@ -293,39 +305,58 @@ replaceHyphenToSlash = convert . T.replace "-" "/" . convert
 
 -- | urlフィールドにファイルからではない適切なurlを入力する。
 cleanUrlField :: Context a
-cleanUrlField = field "url"
-  (fmap (maybe empty $ (replaceHyphenToSlash . cleanUrlString) . toUrl) .
-   getRoute . itemIdentifier)
+cleanUrlField =
+  field
+    "url"
+    ( fmap (maybe empty $ (replaceHyphenToSlash . cleanUrlString) . toUrl)
+        . getRoute
+        . itemIdentifier
+    )
 
 -- | 末尾のindex.htmlを除去してパスだけで閲覧できるようにする。
 cleanUrlString :: String -> String
 cleanUrlString = cleanIndex
-  where cleanIndex path | "/index.html" `L.isSuffixOf` path = dropFileName path
-                        | otherwise = path
+ where
+  cleanIndex path
+    | "/index.html" `L.isSuffixOf` path = dropFileName path
+    | otherwise = path
 
 -- | HTMLとして正しいかをチェックだけして、
 -- 内容は変更せずに返す。
 tidyHtml :: Item String -> Compiler (Item String)
 tidyHtml item = check item >> pure item
-  where check =
-          withItemBody $ unixFilter "tidy"
-          [ "--errors"
-          , "--mute-id", "y"
-          , "--wrap", "0"
-          , "--drop-empty-elements", "n"
-          , "--tidy-mark", "n"
-          -- 古いtidyではHTML属性情報が正しくないことがあるので、チェックを諦めます。
-          , "--warn-proprietary-attributes", "n"
-          ]
+ where
+  check =
+    withItemBody $
+      unixFilter
+        "tidy"
+        [ "--errors"
+        , "--mute-id"
+        , "y"
+        , "--wrap"
+        , "0"
+        , "--drop-empty-elements"
+        , "n"
+        , "--tidy-mark"
+        , "n"
+        , -- 古いtidyではHTML属性情報が正しくないことがあるので、チェックを諦めます。
+          "--warn-proprietary-attributes"
+        , "n"
+        ]
 
 -- | XMLとして正しいかをチェックだけして、
 -- 内容は変更せずに返す。
 tidyXml :: Item String -> Compiler (Item String)
 tidyXml item = check item >> pure item
-  where check =
-          withItemBody $ unixFilter "tidy"
-          [ "--errors"
-          , "--mute-id", "y"
-          , "--wrap", "0"
-          , "-xml"
-          ]
+ where
+  check =
+    withItemBody $
+      unixFilter
+        "tidy"
+        [ "--errors"
+        , "--mute-id"
+        , "y"
+        , "--wrap"
+        , "0"
+        , "-xml"
+        ]


### PR DESCRIPTION
- **ci: Nix flake チェック用 GitHub Actions ワークフローを追加**
- **style(flake): `nix fmt`**
- **refactor(flake): GitHub Actions利用のため不要なciJobsとhydraJobsを除外**
- **build(flake): treefmt-nix を導入してフォーマットチェックを追加**
- **build(flake): `flake.lock`の更新**
- **chore(format): fourmolu設定を更新**
- **chore(editorconfig): 最新版に整備**
- **chore(editor): Emacsのdir-locals.elを追加し保存時のLSPフォーマットを有効化**
- **chore(editorconfig-checker): IndentSizeとMaxLineLengthのルール無効化設定を追加**
- **refactor(nix): overrideAttrs のコールバック引数 oldAttrs を _oldAttrs にリネーム**
- **style(site.hs): fourmoluによるコード整形の更新**
