### PR TITLE
build(deps): Bootstrapを^4.6.2に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lint": "prettier --ignore-path .gitignore --ignore-unknown --check '**/*.{js,jsx,ts,tsx,json,html,css,less,sass,scss,yml,yaml}'"
   },
   "dependencies": {
-    "bootstrap": "^4.6.0"
+    "bootstrap": "^4.6.2"
   },
   "devDependencies": {
     "prettier": "^3.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,7 +616,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bootstrap@npm:^4.6.0":
+"bootstrap@npm:^4.6.2":
   version: 4.6.2
   resolution: "bootstrap@npm:4.6.2"
   peerDependencies:
@@ -1561,7 +1561,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    bootstrap: "npm:^4.6.0"
+    bootstrap: "npm:^4.6.2"
     prettier: "npm:^3.6.2"
     sass: "npm:^1.58.3"
     wrangler: "npm:^3.114.14"


### PR DESCRIPTION
- Bootstrapのバージョンを^4.6.0から^4.6.2に更新
- yarn.lockを再生成