### PR TITLE
style: import文のqualifiedの書き方を統一

### DIFF
--- a/site.hs
+++ b/site.hs
@@ -2,10 +2,10 @@ module Main (main) where
 
 import Control.Applicative
 import Data.Convertible
-import qualified Data.List as L
-import qualified Data.List.Split as L
+import Data.List qualified as L
+import Data.List.Split qualified as L
 import Data.Maybe
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Hakyll
 import System.Directory
 import System.FilePath


### PR DESCRIPTION
`nix flake check`だと対象にならない程度の軽微な問題なので、
これまでエラーにならなかったので気が付かなかった。
まあわざわざ無効化するより新しい形式に統一したほうが良さそうだ。
