### PR TITLE
style: import文の書式を統一しNoImportQualifiedPostを追加

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -17,6 +17,7 @@ default-extensions:
   - GADTs
   - LambdaCase
   - MultiWayIf
+  - NoImportQualifiedPost
   - OverloadedStrings
   - PartialTypeSignatures
   - RecordWildCards

--- a/site.hs
+++ b/site.hs
@@ -2,10 +2,10 @@ module Main (main) where
 
 import Control.Applicative
 import Data.Convertible
-import Data.List qualified as L
-import Data.List.Split qualified as L
+import qualified Data.List as L
+import qualified Data.List.Split as L
 import Data.Maybe
-import Data.Text qualified as T
+import qualified Data.Text as T
 import Hakyll
 import System.Directory
 import System.FilePath


### PR DESCRIPTION
後置にすると何故か`nix flake check`の方のformoluだけがエラーになったり大変ややこしいので前置に統一しました。
こだわりたいポイントではないので。
多分バージョンの違いとかが影響してるんじゃないかと思いますが、
どうでもいいです。
