### PR TITLE
fix(template): Pocketボタンと関連スクリプトを削除

### DIFF
--- a/site/templates/default.html
+++ b/site/templates/default.html
@@ -74,7 +74,6 @@
     <script defer="defer" src="https://b.st-hatena.com/js/comment-widget.js"></script>
 
     <script defer="defer" src="https://b.st-hatena.com/js/bookmark_button.js"></script>
-    <script defer="defer" src="https://widgets.getpocket.com/v1/j/btn.js?v=1"></script>
 
     <script
       defer="defer"
@@ -150,7 +149,6 @@
             loading="lazy"
           />hatena-bookmark
         </a>
-        <a data-pocket-label="pocket" data-pocket-count="horizontal" class="pocket-btn">pocket</a>
       </div>
       <div class="container">
         <!-- www.ncaq.net: フッター上 -->


### PR DESCRIPTION
Pocketがサービス終了していたことを今更知ったので削除。
