### PR TITLE
refactor(flake): nodejs_24をbuildNpmPackageに明示的に指定して依存を整理

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
               pname = "www-ncaq-net";
               version = "0.1.1.0";
               src = ./.;
+              nodejs = final.nodejs_24;
               npmDeps = final.nodeEnv-npmDeps;
               inherit (prev.importNpmLock) npmConfigHook;
               dontNpmBuild = true;
@@ -71,6 +72,7 @@
             nodeEnv-lint = prev.buildNpmPackage {
               name = "www-ncaq-net-lint";
               src = ./.;
+              nodejs = final.nodejs_24;
               npmDeps = final.nodeEnv-npmDeps;
               inherit (prev.importNpmLock) npmConfigHook;
               npmBuildScript = "lint";
@@ -114,7 +116,6 @@
                           final.lib.makeBinPath [
                             final.html-tidy
                             final.nodeEnv
-                            final.nodejs_24
                             final.pythonEnv
                           ]
                         } \


### PR DESCRIPTION
- Node.js を 24 に統一して約90 MiBを削減
- クロージャサイズ: 958.1 MiB → 868.2 MiB
