### PR TITLE
feat: mcp-nixosのHTTPエンドポイントをmicrovm.nixで建ててパブリックに公開しました

### DIFF
--- a/site/entry/2026-02-18-23-40-06.md
+++ b/site/entry/2026-02-18-23-40-06.md
@@ -409,7 +409,7 @@ mcp-nixosのHTTPエンドポイントをmicrovm.nixで建ててパブリック�
 - AndroidのClaude(claude.ai)からNixOS情報にアクセスするのが目的
 - 読み取り専用MCPに認証は不要と判断してパブリック公開
 - microvm.nixでcloud-hypervisorベースの仮想マシンに隔離
-- 帯域制限やsystemdハードニングでDoS対策
+- 帯域制限やsystemdハードニングで踏み台対策
 - Cloudflare Tunnel経由で`https://mcp-nixos.ncaq.net/mcp/`として公開
 - 既存のコンテナ管理と統一するためmachine-mapping.nixに一元化
 


### PR DESCRIPTION
- **feat: mcp-nixosのHTTPエンドポイントをmicrovm.nixで建てた記事を追加**
- **feat: PR #606のsystemd-networkd移行についての記述を追加**
- **feat: 記事を微修正**
- **fix: mcp-nixosのHTTPエンドポイント記事の表現や誤字を修正**
