### PR TITLE
feat: メタデータ属性のバリデーション機能を追加

### DIFF
--- a/www-ncaq-net.cabal
+++ b/www-ncaq-net.cabal
@@ -47,7 +47,9 @@ executable www-ncaq-net
     TemplateHaskell
 
   build-depends:
+    aeson,
     base,
+    containers,
     convertible,
     directory,
     filepath,


### PR DESCRIPTION
close #130

`published`属性は`date`と同じにする予定でしたが、
結局使わないのでこれを機に廃止することにします。

- 許可されていないメタデータ属性が存在する場合はビルドを失敗させます
- 許可属性は title, date, updated のみです
- 依存パッケージに aeson, containers を追加しました
