### PR TITLE
build: nix-templatesによる最新の設定をマージ

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,12 +35,12 @@ trim_trailing_whitespace = false
 indent_size = unset
 
 [*.{json,md,nix,yml,yaml}]
-# 設定やドキュメントのファイルはURLなど改行困難なものが多いため行幅制限を緩めます。
-max_line_length = 300
+# 設定やドキュメントのファイルはURLなど改行困難なものが多いため行幅制限を無効化します。
+max_line_length = unset
 
 [.env{,.*}]
 # 接続文字列やAPIキーなど長い設定値を含むため行幅制限を無効化します。
-max_line_length = off
+max_line_length = unset
 
 [*.bat]
 charset = latin1

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - "Type: Release"
+
+  categories:
+    - title: Security Fixes
+      labels: ["Type: Security"]
+    - title: Breaking Changes
+      labels: ["Type: Breaking Change"]
+    - title: Features
+      labels: ["Type: Feature"]
+    - title: Bug Fixes
+      labels: ["Type: Bug"]
+    - title: Documentation
+      labels: ["Type: Documentation"]
+    - title: Refactoring
+      labels: ["Type: Refactoring"]
+    - title: Testing
+      labels: ["Type: Testing"]
+    - title: CI
+      labels: ["Type: CI"]
+    - title: Dependency Updates
+      labels: ["Type: Dependencies", "dependencies"]
+    - title: Other Changes
+      labels: ["*"]

--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read # Read repository contents for checkout
       id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
-    uses: ncaq/kyosei-action/.github/workflows/review.yml@60b1d2f437865f176811f21e5cc0c5417f50f390 # v1.5.0
+    uses: ncaq/kyosei-action/.github/workflows/review.yml@45c290cb5b5d09caae05c7718efc83c41a976d43 # v2.0.2
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>ncaq/renovate-config"]
+}


### PR DESCRIPTION
nix-templatesの最新内容に合わせて設定ファイルを更新しました。

- `.editorconfig`: `max_line_length`の値を`300`/`off`から`unset`に統一。テンプレートでコメントも「緩めます」→「無効化します」に改められていたため合わせました。
- `.github/release.yml`: テンプレートに存在するGitHubリリースのchangelog設定ファイルを新規追加しました。
- `.github/workflows/kyosei.yml`: kyosei-actionをv1.5.0からv2.0.2に更新しました。
- `renovate.json`: テンプレートに存在するRenovate設定ファイルを新規追加しました。