### PR TITLE
fix: 未使用custom property検出時に非customの宣言名を混入させない

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,11 @@ const dummyCssEntry = "virtual:css-bundle-noop" as const;
  * Declaration/DeclarationExit visitorで現在のcustom property名をスタックに積めば、
  * Variable visitorは現在地が内側か外側かを判定できる。
  *
+ * `Declaration.custom`はlightningcssがパースできなかった宣言全般に呼ばれるため、
+ * `content: "..." / "..."`のような未対応構文の宣言名(`content`等)が混入する。
+ * これを`unusedSymbols`に渡すと該当ルール自体が削除されてしまうため、
+ * `--`で始まる本物のcustom propertyだけを対象に絞る。
+ *
  * 結果はlightningcssの`unusedSymbols`にそのまま渡せる`--`付きの名前。
  */
 function collectUnusedCustomProperties(): string[] {
@@ -39,6 +44,9 @@ function collectUnusedCustomProperties(): string[] {
       Declaration: {
         custom(property) {
           const name = property.name;
+          if (!name.startsWith("--")) {
+            return;
+          }
           currentCustomProperty = name;
           if (!definitions.has(name)) {
             definitions.set(name, new Set<string>());
@@ -46,7 +54,10 @@ function collectUnusedCustomProperties(): string[] {
         },
       },
       DeclarationExit: {
-        custom() {
+        custom(property) {
+          if (!property.name.startsWith("--")) {
+            return;
+          }
           currentCustomProperty = undefined;
         },
       },


### PR DESCRIPTION
`Declaration.custom`はlightningcssがパースできなかった宣言全般に呼ばれるため、
`h1::before { content: "# " / ""; }`のような未対応の代替テキスト構文を持つ宣言だと、
`content`という名前が`definitions`に登録されていました。
結果`unusedSymbols`に文字列`content`が混入し、
lightningcssが`content`プロパティを含むルールごと削除してしまい、
見出しの`::before`装飾が出力CSSから消えていました。

`--`で始まる本物のcustom propertyだけを対象に絞ることで、
未対応構文の宣言名が`unusedSymbols`に紛れ込まないようにします。
