### PR TITLE
build(uv): exclude-newerとexclude-newer-spanオプションを追加

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[options]
+exclude-newer = "2026-05-21T03:44:00.59810674Z"
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "pygments"
 version = "2.20.0"


### PR DESCRIPTION
ビルドしたところグローバルのuvの設定の、
<https://github.com/ncaq/dotfiles/blob/67becc99598aa4342cb979010930936a21e6cf6a/home/core/python.nix#L20>
から自動的に付与されました。
