### PR TITLE
fix(run): assetディレクトリのマッチパターンを修正

### DIFF
--- a/src/Run.hs
+++ b/src/Run.hs
@@ -35,7 +35,7 @@ hakyllRun options (entryIndex, years) = hakyllWithArgs conf options $ do
           , "*.webp"
           ]
 
-  match (imageExtension .||. "*.txt" .||. "_headers" .||. "asset/**/*") $ do
+  match (imageExtension .||. "*.txt" .||. "_headers" .||. "asset/*") $ do
     route idRoute
     compile copyFileCompiler
 

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -35,7 +35,7 @@ hakyllRun options (entryIndex, years) = hakyllWithArgs conf options $ do
           , "*.webp"
           ]
 
-  match (imageExtension .||. "*.txt" .||. "_headers" .||. "asset/*") $ do
+  match (imageExtension .||. "*.txt" .||. "_headers" .||. "asset/**") $ do
     route idRoute
     compile copyFileCompiler
 


### PR DESCRIPTION
前の書き方だとサブディレクトリの内部じゃないとマッチしませんでした。
今の書き方だと直接置いてもサブディレクトリでもマッチします。
