### PR TITLE
feat: プレビューサーバ起動時に自動でブラウザを開く機能を追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,7 @@
                     pkgs.nodejs
                     pkgs.uv
                     pkgs.wrangler
+                    pkgs.xdg-utils
 
                     html-tidy
                     pythonEnv

--- a/src/Browser.hs
+++ b/src/Browser.hs
@@ -30,26 +30,23 @@ waitForPort host port = go 600
   go n
     | n <= 0 = pure False
     | otherwise = do
-        connected <- tryConnect host port
-        if connected
-          then return True
-          else threadDelay 100000 >> go (n - 1)
+        connected <- tryConnectToServer host port
+        case connected of
+          Right () -> return True
+          _ -> threadDelay 100000 >> go (n - 1)
 
--- | TCPポートへの接続を一度だけ試みます。
-tryConnect :: String -> Int -> IO Bool
-tryConnect host port = do
+-- | サーバへの接続を一度だけ試みます。
+tryConnectToServer :: (Show a) => HostName -> a -> IO (Either SomeException ())
+tryConnectToServer host port = try $ do
   let hints = defaultHints{addrSocketType = Stream}
   addrs <- getAddrInfo (Just hints) (Just host) (Just (show port))
-  result <- try $ case addrs of
+  case addrs of
     [] -> throwIO $ userError "アドレス解決に失敗しました"
     addr : _ ->
       bracket
         (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
         close
         (`connect` addrAddress addr)
-  return $ case result :: Either SomeException () of
-    Left _ -> False
-    Right () -> True
 
 -- | URLを開きます。
 openBrowser :: String -> Int -> IO ()

--- a/src/Browser.hs
+++ b/src/Browser.hs
@@ -1,0 +1,62 @@
+module Browser
+  ( openBrowserWhenReady
+  ) where
+
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
+import Network.Socket
+import System.Exit
+import qualified System.Process.Typed as P
+
+-- | プレビューサーバが起動した後にwebブラウザでプレビューを開きます。
+-- Hakyllのプレビューサーバ起動はブロッキングなので別スレッドで処理します。
+-- ポートに接続できるようになるまで待ってからブラウザを起動することで、
+-- サーバの初回ビルド完了前にブラウザを開いてしまうことを防ぎます。
+openBrowserWhenReady :: String -> Int -> IO ThreadId
+openBrowserWhenReady host port = forkIO $ do
+  ready <- waitForPort host port
+  if ready
+    then openBrowser host port
+    else throwIO $ userError "サーバの起動に失敗しました"
+
+-- | 指定したポートにTCP接続できるようになるまで一定間隔で待ちます。
+-- 接続できたら`True`、
+-- 規定回数試しても駄目なら`False`を返します。
+waitForPort :: String -> Int -> IO Bool
+waitForPort host port = go 600
+ where
+  go :: Int -> IO Bool
+  go n
+    | n <= 0 = pure False
+    | otherwise = do
+        connected <- tryConnect host port
+        if connected
+          then return True
+          else threadDelay 100000 >> go (n - 1)
+
+-- | TCPポートへの接続を一度だけ試みます。
+tryConnect :: String -> Int -> IO Bool
+tryConnect host port = do
+  let hints = defaultHints{addrSocketType = Stream}
+  addrs <- getAddrInfo (Just hints) (Just host) (Just (show port))
+  result <- try $ case addrs of
+    [] -> throwIO $ userError "アドレス解決に失敗しました"
+    addr : _ ->
+      bracket
+        (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+        close
+        (`connect` addrAddress addr)
+  return $ case result :: Either SomeException () of
+    Left _ -> False
+    Right () -> True
+
+-- | URLを開きます。
+openBrowser :: String -> Int -> IO ()
+openBrowser host port = do
+  let url = "http://" <> host <> ":" <> show port
+  exitCode <- P.runProcess $ P.proc "xdg-open" [url]
+  unless (exitCode == ExitSuccess) $
+    throwIO $
+      userError $
+        "ブラウザの起動に失敗しました" <> " (exit code: " <> show exitCode <> ")"

--- a/src/Integration.hs
+++ b/src/Integration.hs
@@ -3,11 +3,12 @@ module Integration (integrateExec) where
 import Hakyll
 import Vite
 
--- | Viteの処理とHakyllの処理を統合する関数。
+-- | Hakyllの処理とViteなど外部プロセスの処理を統合してコマンドを実行します。
 integrateExec :: Options -> IO () -> IO ()
 integrateExec options runHakyll = do
-  -- サイト生成を行うサブコマンドの場合のみ、Viteでスタイルシートをバンドルする。
-  -- `site/dist/bundle.css`がprovideDirectory配下に出力されるので、
+  -- サイト生成を行うサブコマンドの場合のみ、
+  -- Viteでスタイルシートをバンドルする。
+  -- `site/dist/bundle.css`が`provideDirectory`配下に出力されるので、
   -- 後続のHakyllが通常通り検出してコピーできる。
   case optCommand options of
     Build{} -> runViteBuild >> runHakyll

--- a/src/Integration.hs
+++ b/src/Integration.hs
@@ -1,5 +1,7 @@
 module Integration (integrateExec) where
 
+import Browser
+import Control.Monad
 import Hakyll
 import Vite
 
@@ -15,6 +17,11 @@ integrateExec options runHakyll = do
     Rebuild -> runViteBuild >> runHakyll
     -- watch/serverではViteもwatchモードで動かして、
     -- スタイル変更時にバンドルを更新し続ける。
-    Watch{} -> withViteWatch runHakyll
-    Server{} -> withViteWatch runHakyll
+    -- 合わせてプレビューサーバが起動したらwebブラウザでプレビューを開く。
+    Watch{host, port, no_server} -> do
+      unless no_server $ void $ openBrowserWhenReady host port
+      withViteWatch runHakyll
+    Server{host, port} -> do
+      void $ openBrowserWhenReady host port
+      withViteWatch runHakyll
     _ -> runHakyll

--- a/www-ncaq-net.cabal
+++ b/www-ncaq-net.cabal
@@ -58,6 +58,7 @@ executable www-ncaq-net
     directory,
     filepath,
     hakyll >=4.12.5.2,
+    network,
     pandoc ^>=3.7.0.2,
     regex-tdfa,
     split,
@@ -67,6 +68,7 @@ executable www-ncaq-net
   -- cabal-gild: discover ./src --exclude=**/Main.hs
   other-modules:
     BasicContext
+    Browser
     Configuration
     EntryAndYears
     EntryContext


### PR DESCRIPTION
`watch`や`server`でプレビューサーバを起動したとき、
これまでは自分でブラウザを開いてURLを入力する必要がありました。
この手間をなくすために、
プレビューサーバの起動を検知して自動でブラウザを開く機能を追加します。

サーバがポートを開くのを待ってから`xdg-open`でブラウザを起動する`Browser`モジュールを追加し、
`Integration`の`watch`/`server`実行時に呼び出すようにしました。
ポートが開く前にブラウザを開いてしまうと接続エラーになるため、
ポートの待機処理を挟んでいます。

これに伴い必要な依存として`network`と`xdg-utils`をcabalとflake.nixに追加しています。