### PR TITLE
build: `pyproject.toml`に`exclude-newer = "P3D"`を明記

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ description = ""
 authors = [{ name = "ncaq", email = "ncaq@ncaq.net" }]
 requires-python = ">=3.12"
 dependencies = ["pygments>=2.19.0"]
+
+[tool.uv]
+exclude-newer = "P3D"


### PR DESCRIPTION
サプライチェーン攻撃対策として`uv.lock`の`[options]`に3日のdelayを入れていますが、
これはグローバルの`~/.config/uv/uv.toml`に書いた設定に由来していて、
Renovateの実行環境にはそのグローバル設定が存在しないため、
Renovateが`uv.lock`を再生成すると`[options]`セクションが消えてしまっていました。

プロジェクトの`[tool.uv]`に同じ設定を書くことで、
グローバル設定の有無に依らずどの実行環境でも3日のdelayが適用されるようにします。
uvは`[tool.uv] exclude-newer`にISO 8601 duration形式(`P3D`)を直接書けます。
