### PR TITLE
ci: チェックワークフローのタイムアウトを延長

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read # リポジトリコンテンツの読み取り
       id-token: write # niks3 OIDC認証
-    timeout-minutes: 15
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
それなりに様々な依存関係が存在しており、
特にHaskellの依存関係はキャッシュが切れていればかなり時間がかかるため、
タイムアウトを延長します。
そもそもとりあえず設置しているだけで、
そこまでタイムアウトを設定することに思い入れはないため。
