### PR TITLE
feat: 日時をサーバサイドで日本語表記にレンダリング

### DIFF
--- a/site/entry-index.html
+++ b/site/entry-index.html
@@ -10,9 +10,9 @@
     <a href="$url$">
       <section class="entry-preview">
         <header>
-          <time datetime="$date$">$date$</time>
+          <time datetime="$date$">$date-japanese$</time>
           $if(updated)$ :
-          <time datetime="$updated$">$updated$</time>
+          <time datetime="$updated$">$updated-japanese$</time>
           $endif$
         </header>
         <h2>$title$</h2>

--- a/site/index.html
+++ b/site/index.html
@@ -12,9 +12,9 @@
       <a href="$url$">
         <section class="entry-preview">
           <header>
-            <time datetime="$date$">$date$</time>
+            <time datetime="$date$">$date-japanese$</time>
             $if(updated)$ :
-            <time datetime="$updated$">$updated$</time>
+            <time datetime="$updated$">$updated-japanese$</time>
             $endif$
           </header>
           <h2>$title$</h2>

--- a/site/templates/entry.html
+++ b/site/templates/entry.html
@@ -1,8 +1,8 @@
 <article>
   <ul class="timestamp">
-    <li>作成: <wbr /><time datetime="$date$">$date$</time></li>
+    <li>作成: <wbr /><time datetime="$date$">$date-japanese$</time></li>
     $if(updated)$
-    <li>更新: <wbr /><time datetime="$updated$">$updated$</time></li>
+    <li>更新: <wbr /><time datetime="$updated$">$updated-japanese$</time></li>
     $endif$
   </ul>
   <h1>$title$</h1>

--- a/src/EntryContext.hs
+++ b/src/EntryContext.hs
@@ -6,6 +6,7 @@ import Escape
 import Hakyll
 import Himari hiding (Context)
 import Teaser
+import Timestamp
 import Title
 
 -- | Markdownの記事として独立しているページ向け。
@@ -26,14 +27,31 @@ entryContext =
         ]
  where
   titleEscape = mapTitleEx (fmap escapeHtml)
+  -- 機械可読な`datetime`属性向けにISO 8601の値を残しつつ、
+  -- 表示用に日本語表記へ変換したフィールドも提供する。
   entryDate =
-    field
-      "date"
-      $ \item -> do
-        mMeta <- getMetadataField (itemIdentifier item) "date"
-        case mMeta of
-          Nothing -> return . fromMaybe empty $ mItemDate item
-          Just meta -> return meta
+    mconcat
+      [ field "date" $ fmap (fromMaybe empty) . itemIsoDate
+      , field "date-japanese" $ \item -> do
+          mIso <- itemIsoDate item
+          case mIso of
+            Nothing -> pure empty
+            Just isoDate -> toJapaneseOrFail isoDate
+      , field "updated-japanese" $ \item -> do
+          mUpdated <- getMetadataField (itemIdentifier item) "updated"
+          case mUpdated of
+            Nothing -> noResult "updatedメタデータが存在しない"
+            Just updated -> toJapaneseOrFail updated
+      ]
+  -- ISO 8601形式の文字列を日本語表記に変換する。
+  -- 解釈できない場合はフォールバックせずにビルドを失敗させる。
+  toJapaneseOrFail isoDate =
+    maybe (fail $ "日時を解釈できませんでした: " <> isoDate) pure $ formatJapanese isoDate
+  -- 記事の作成日時をISO 8601形式で取得する。
+  -- メタデータの`date`を優先し、無ければファイル名から導出する。
+  itemIsoDate item = do
+    mMeta <- getMetadataField (itemIdentifier item) "date"
+    pure $ mMeta <|> mItemDate item
   mItemDate item = case L.splitOneOf "-" f of
     [year, month, day, hour, minute, second] ->
       Just $ concat [year, "-", month, "-", day, "T", hour, ":", minute, ":", second, "+09:00"]

--- a/src/Timestamp.hs
+++ b/src/Timestamp.hs
@@ -1,0 +1,65 @@
+module Timestamp
+  ( formatJapanese
+  ) where
+
+import Data.Time.Format.ISO8601 (iso8601ParseM)
+import Himari hiding (Context)
+
+-- | ISO 8601形式の日時文字列を日本人向けの表記に変換する。
+-- 日時を含む場合は @2025年12月30日(火)15時41分18秒@、
+-- 日付のみの場合は @2025年12月30日(火)@ を返す。
+-- 桁幅を常に揃えるため、月日と時分秒は2桁のゼロ埋めで表示する。
+-- 解釈できない文字列の場合は'Nothing'を返す。
+formatJapanese :: String -> Maybe String
+formatJapanese s =
+  (formatZonedTime <$> iso8601ParseM s)
+    <|> (formatDay <$> iso8601ParseM s)
+
+-- | 日時を日本語表記に変換する。
+formatZonedTime :: ZonedTime -> String
+formatZonedTime zonedTime =
+  let localTime = zonedTimeToLocalTime zonedTime
+   in formatDay (localDay localTime) <> formatTimeOfDay (localTimeOfDay localTime)
+
+-- | 日付部分を @2025年12月30日(火)@ の形式に変換する。
+formatDay :: Day -> String
+formatDay day =
+  let (year, month, dayOfMonth) = toGregorian day
+   in mconcat
+        [ show year
+        , "年"
+        , zeroPad2 month
+        , "月"
+        , zeroPad2 dayOfMonth
+        , "日("
+        , formatDayOfWeek (dayOfWeek day)
+        , ")"
+        ]
+
+-- | 時刻部分を @15時41分18秒@ の形式に変換する。
+formatTimeOfDay :: TimeOfDay -> String
+formatTimeOfDay timeOfDay =
+  mconcat
+    [ zeroPad2 (todHour timeOfDay)
+    , "時"
+    , zeroPad2 (todMin timeOfDay)
+    , "分"
+    , zeroPad2 (floor (todSec timeOfDay) :: Int)
+    , "秒"
+    ]
+
+-- | 整数を2桁のゼロ埋め文字列に変換する。
+zeroPad2 :: Int -> String
+zeroPad2 n =
+  let s = show n
+   in if length s < 2 then '0' : s else s
+
+-- | 曜日を日本語1文字に変換する。
+formatDayOfWeek :: DayOfWeek -> String
+formatDayOfWeek Monday = "月"
+formatDayOfWeek Tuesday = "火"
+formatDayOfWeek Wednesday = "水"
+formatDayOfWeek Thursday = "木"
+formatDayOfWeek Friday = "金"
+formatDayOfWeek Saturday = "土"
+formatDayOfWeek Sunday = "日"

--- a/www-ncaq-net.cabal
+++ b/www-ncaq-net.cabal
@@ -82,6 +82,7 @@ executable www-ncaq-net
     regex-tdfa,
     split,
     text,
+    time,
 
   -- cabal-gild: discover ./src --exclude=**/Main.hs
   other-modules:
@@ -101,5 +102,6 @@ executable www-ncaq-net
     Runner
     Teaser
     Tidy
+    Timestamp
     Title
     Vite


### PR DESCRIPTION
ISO 8601をべた書きしていたユーザ向けの日時表示を、
`2025年12月30日(火)15時41分18秒`のような日本語表記に変換するようにしました。

日本語しか書いていないサイトなので、
閲覧者の環境に合わせてクライアントで変換する必要はないと判断し、
Hakyllのビルド時にサーバサイドで変換します。

新設した`Timestamp`モジュールの`formatJapanese`でISO 8601文字列をパースし、
日時を含む場合は曜日と時刻まで、
日付のみの場合は曜日までを日本語表記で出力します。
桁幅を常に揃えるため、
月日と時分秒は2桁のゼロ埋めで表示します。

機械可読性を保つため`<time>`要素の`datetime`属性はISO 8601のまま残し、
表示テキストだけを`date-japanese`と`updated-japanese`の新フィールドに差し替えました。

日時を解釈できなかった場合はフォールバックせず、
ビルドを失敗させて誤った表示が公開されるのを防ぎます。

close #126
