### PR TITLE
build(deps): bump nixpkgs to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,16 +53,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "static site generator for www.ncaq.net by Hakyll";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
nixpkgs を最新安定版の `nixos-26.05` に更新します。

`flake.nix` のチャンネル参照を `nixos-25.11` から `nixos-26.05` に変更し、`nix flake update nixpkgs` で `flake.lock` を再生成しました。

ビルド検証は CI に任せます。